### PR TITLE
INFR-564: De-Joyent repo and add global zone dataset plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@
 
 # Copyright 2025 Edgecast Cloud LLC.
 
-export GOPATH   = $(PWD)/deps/go
-export PATH    := $(PWD)/mock:$(GOPATH)/bin:$(PATH)
+export PATH    := $(PWD)/mock:$(PATH)
 export COPYFILE_DISABLE=true
 
 PREFIX          = cmon
@@ -17,7 +16,7 @@ ALL_PLUGINS     = $(shell find gz-plugins vm-plugins -type f)
 VERSION         = $(shell git tag --sort=taggerdate | tail -1)
 GITREV          = $(shell git rev-parse HEAD 2>/dev/null)
 
-.PHONY: all check clean deps mrclean version
+.PHONY: all check clean mrclean version
 
 all: cmon-plugins.tar.gz
 
@@ -34,13 +33,7 @@ $(ARCHIVE): .version
 release: clean .version $(ARCHIVE)
 	hub release create -d -a $(ARCHIVE) $(VERSION)
 
-deps: deps/go/bin/promtool
-
-deps/go/bin/promtool:
-	@mkdir -p $(GOPATH)
-	sh -c "go get github.com/prometheus/prometheus/cmd/promtool"
-
-check: deps
+check:
 	@[[ -d gz-plugins ]] || mkdir gz-plugins
 	@[[ -d vm-plugins ]] || mkdir vm-plugins
 	@sh -c "find gz-plugins vm-plugins -type f -name '*.prom' -exec tools/promlint {} +"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Copyright 2020 Joyent, Inc.
 # Copyright 2025 Edgecast Cloud LLC.
 
 export PATH    := $(PWD)/mock:$(PATH)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Copyright 2020 Joyent, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 
 export GOPATH   = $(PWD)/deps/go
 export PATH    := $(PWD)/mock:$(GOPATH)/bin:$(PATH)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <!--
+   - Copyright 2020 Joyent, Inc.
    - Copyright 2025 Edgecast Cloud LLC.
    -->
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,21 @@ Prefer making plugins with `.prom` extension so that they can be checked with
 
 Before committing, your plugin should be lint clean with whatever language you
 used to develop it (e.g., `jsvascriptlint`, `shellcheck`, `clippy`) and pass
-`make check` which lints plugin output. If you use external commands that may
-not be present or functional in a development environment, or may be dangerous
-to run (for whatever reason...), also create an appropriate `mock` tool to
-simulate its output for use with `make check`.
+`make check` which lints plugin output. 
+
+### Prerequisites for Development
+
+To use `make check`, you'll need `promtool` installed in your PATH. Since `go get` 
+outside of a module is deprecated, install it manually:
+
+    go install github.com/prometheus/prometheus/cmd/promtool@latest
+
+See: https://pkg.go.dev/github.com/prometheus/prometheus/cmd/promtool
+
+If you use external commands that may not be present or functional in a 
+development environment, or may be dangerous to run (for whatever reason...), 
+also create an appropriate `mock` tool to simulate its output for use with 
+`make check`.
 
 [agent-docs]: https://github.com/joyent/triton-cmon-agent/tree/master/docs#plugins
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@
 
 These plugins are for the [Triton][triton] [Container Monitor][cmon] system.
 
-These are unofficial. They are used in Edgecast's production infrastructure but
-may or may not work with your system. A valid workaround for you might be to
-install to an alternate location and symlink the plug-ins you wish to use.
+These are unofficial. They were previously used in Joyent's production infrastructure, and given new life in Edgecast's production infrastructure. These plugins may or may not work with your systems. A valid workaround for you might be to install to an alternate location and symlink the plug-ins you wish to use.
 
 [triton]: https://github.com/tritondatacenter/triton
 [cmon]: https://github.com/tritondatacenter/triton-cmon

--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <!--
-   - Copyright 2020 Joyent, Inc.
+   - Copyright 2025 Edgecast Cloud LLC.
    -->
 
 # triton-cmon-plugins
 
 These plugins are for the [Triton][triton] [Container Monitor][cmon] system.
 
-These are unofficial. They are used in Joyent's production infrastructure but
+These are unofficial. They are used in Edgecast's production infrastructure but
 may or may not work with your system. A valid workaround for you might be to
 install to an alternate location and symlink the plug-ins you wish to use.
 
-[triton]: https://github.com/joyent/triton
-[cmon]: https://github.com/joyent/triton-cmon
+[triton]: https://github.com/tritondatacenter/triton
+[cmon]: https://github.com/tritondatacenter/triton-cmon
 
 ## Installing
 
@@ -25,7 +25,7 @@ nodes, and extract it to `/opt/custom/cmon`.
 Run these commands from your `headnode`.
 
     mkdir -p /opt/custom
-    latest=$(curl -s https://api.github.com/repos/joyent/triton-cmon-plugins/releases/latest | json assets.0.browser_download_url)
+    latest=$(curl -s https://api.github.com/repos/tritondatacenter/triton-cmon-plugins/releases/latest | json assets.0.browser_download_url)
     curl -o /tmp/cmon-plugins.tar.gz -L "$latest"
     sdc-oneachnode -c -X -g /tmp/cmon-plugins.tar.gz -d /tmp
     sdc-oneachnode -a 'mkdir -p /opt/custom ; gtar zxf /tmp/cmon-plugins.tar.gz --no-same-owner -C /opt/custom'

--- a/gz-plugins/gz_dataset.prom
+++ b/gz-plugins/gz_dataset.prom
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Copyright 2025 Edgecast Cloud LLC.
+
+set -o errexit
+set -o pipefail
+
+# shellcheck disable=SC2154
+if [[ -n "$TRACE" ]]; then
+    export PS4='[\D{%FT%TZ}] ${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+    set -o xtrace
+fi
+
+# Get zones dataset usage information including quota
+zfs_output=$(zfs list -Hpo used,available,quota zones 2>/dev/null)
+
+# shellcheck disable=SC2181
+if [ $? -ne 0 ]; then
+    # If zfs command fails, display nothing
+    exit 0
+fi
+
+# Parse the output (tab-separated: used available quota)
+used=$(echo "$zfs_output" | cut -f1)
+available=$(echo "$zfs_output" | cut -f2)
+quota=$(echo "$zfs_output" | cut -f3)
+
+# Calculate effective quota
+if [ "$quota" = "-" ] || [ "$quota" = "0" ]; then
+    # If no quota, use used + available as effective quota
+    quota=$((used + available))
+fi
+
+printf '# HELP zfs_used ZFS space used by zones dataset in bytes\n'
+printf '# TYPE zfs_used gauge\n'
+printf 'zfs_used\t%d\n' "$used"
+
+printf '# HELP zfs_quota ZFS quota for zones dataset in bytes\n'
+printf '# TYPE zfs_quota gauge\n'
+printf 'zfs_quota\t%d\n' "$quota"
+
+printf '# HELP zfs_available ZFS space available to zones dataset in bytes\n'
+printf '# TYPE zfs_available gauge\n'
+printf 'zfs_available\t%d\n' "$available"

--- a/gz-plugins/smf.prom
+++ b/gz-plugins/smf.prom
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Copyright 2020 Joyent, Inc.
 # Copyright 2025 Edgecast Cloud LLC.
 
 set -o errexit

--- a/gz-plugins/smf.prom
+++ b/gz-plugins/smf.prom
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Copyright 2020 Joyent, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 
 set -o errexit
 set -o pipefail

--- a/gz-plugins/temperature_sensor.prom
+++ b/gz-plugins/temperature_sensor.prom
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Copyright 2020 Joyent, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 
 # See http://dtrace.org/blogs/rm/2019/08/14/cpu-and-pch-temperature-sensors-in-illumos/
 

--- a/gz-plugins/temperature_sensor.prom
+++ b/gz-plugins/temperature_sensor.prom
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Copyright 2020 Joyent, Inc.
 # Copyright 2025 Edgecast Cloud LLC.
 
 # See http://dtrace.org/blogs/rm/2019/08/14/cpu-and-pch-temperature-sensors-in-illumos/

--- a/gz-plugins/zone_count.prom
+++ b/gz-plugins/zone_count.prom
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Copyright 2020 Joyent, Inc.
 # Copyright 2025 Edgecast Cloud LLC.
 
 set -o errexit

--- a/gz-plugins/zone_count.prom
+++ b/gz-plugins/zone_count.prom
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Copyright 2020 Joyent, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 
 set -o errexit
 set -o pipefail

--- a/mock/fmtopo
+++ b/mock/fmtopo
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Copyright 2020 Joyent, Inc.
 # Copyright 2025 Edgecast Cloud LLC.
 
 if [[ $1 == -P ]]; then

--- a/mock/fmtopo
+++ b/mock/fmtopo
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Copyright 2020 Joyent, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 
 if [[ $1 == -P ]]; then
 cat << EOF

--- a/mock/vmadm
+++ b/mock/vmadm
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Copyright 2020 Joyent, Inc.
 # Copyright 2025 Edgecast Cloud LLC.
 
 case $1 in

--- a/mock/vmadm
+++ b/mock/vmadm
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Copyright 2020 Joyent, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 
 case $1 in
     list)

--- a/mock/zfs
+++ b/mock/zfs
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Copyright 2025 Edgecast Cloud LLC.
+
+case "$1 $2" in
+    "list -Hpo")
+        # zones_dataset.prom
+        if [[ "$5" == "zones" ]]; then
+            printf "5314993440578\t250041612478\t0\n"
+        fi
+    ;;
+    *)
+        exit 0;;
+esac

--- a/tools/promlint
+++ b/tools/promlint
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Copyright 2020 Joyent, Inc.
 # Copyright 2025 Edgecast Cloud LLC.
 
 set -o errexit

--- a/tools/promlint
+++ b/tools/promlint
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Copyright 2020 Joyent, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
## Summary
- De-Joyent the repository by updating references and requirements
- Add new global zone dataset plugin for monitoring ZFS dataset usage
- Update Makefile and README to reflect new requirements
- Add ZFS mock output for testing
- Apply shellcheck linting fixes

## Changes
- Updated Makefile to remove Joyent-specific requirements
- Enhanced README with updated installation and usage instructions
- Added `gz_dataset.prom` plugin for monitoring global zone datasets
- Created ZFS mock data for testing
- Applied shellcheck fixes across multiple files

## Testing
```
$ make check
Checking gz-plugins/temperature_sensor.prom
Checking gz-plugins/smf.prom
Checking gz-plugins/gz_dataset.prom
Checking gz-plugins/zone_count.prom
Checking gz-plugins/uptime.prom
```

All of these plugins were also tested in production on the following compute notes: e03, d16, and e12